### PR TITLE
Linksys WUSB6400M added

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -223,6 +223,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	/*=== Realtek demoboard ===*/
 	{USB_DEVICE(0x0B05, 0x1812), .driver_info = RTL8812}, /* ASUS - Edimax */
 	{USB_DEVICE(0x7392, 0xB822), .driver_info = RTL8822B}, /* Edimax - EW-7822ULC */
+	{USB_DEVICE(0x13B1, 0x0043), .driver_info = RTL8822B}, /* Linksys - WUSB6400M */
 	{USB_DEVICE(0x0BDA, 0xB812), .driver_info = RTL8822B},
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xB82C, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* Default ID */
 #endif /* CONFIG_RTL8822B */


### PR DESCRIPTION
Linksys WUSB6400M(usb id 13b1:0043) added. 
Device tested on Linux ubuntu 4.13.0-21-generic.
Refer https://wikidevi.com/wiki/Linksys_WUSB6400M
  