### PR TITLE
Add support for the new timer interface

### DIFF
--- a/hal/phydm/phydm_types.h
+++ b/hal/phydm/phydm_types.h
@@ -153,7 +153,11 @@ typedef enum _RT_SPINLOCK_TYPE{
 
 	typedef struct rtl8192cd_priv	*prtl8192cd_priv;
 	typedef struct stat_info		STA_INFO_T,*PSTA_INFO_T;
+#if defined (LINUX_VERSION_CODE) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	typedef struct legacy_timer_emu		RT_TIMER, *PRT_TIMER;
+#else
 	typedef struct timer_list		RT_TIMER, *PRT_TIMER;
+#endif
 	typedef  void *				RT_TIMER_CALL_BACK;
 
 #ifdef CONFIG_PCI_HCI
@@ -223,7 +227,11 @@ typedef enum _RT_SPINLOCK_TYPE{
 		#define	ODM_ENDIAN_TYPE			ODM_ENDIAN_BIG
 	#endif
 	
+#if defined (LINUX_VERSION_CODE) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	typedef struct legacy_timer_emu		RT_TIMER, *PRT_TIMER;
+#else
 	typedef struct timer_list		RT_TIMER, *PRT_TIMER;
+#endif
 	typedef  void *				RT_TIMER_CALL_BACK;
 	#define	STA_INFO_T			struct sta_info
 	#define	PSTA_INFO_T		struct sta_info *

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -322,7 +322,11 @@ extern void rtw_init_timer(_timer *ptimer, void *padapter, void *pfunc);
 __inline static unsigned char _cancel_timer_ex(_timer *ptimer)
 {
 #ifdef PLATFORM_LINUX
+# if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	return del_timer_sync(&ptimer->t);
+# else
 	return del_timer_sync(ptimer);
+# endif
 #endif
 #ifdef PLATFORM_FREEBSD
 	_cancel_timer(ptimer, 0);

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -133,7 +133,15 @@ typedef struct mutex		_mutex;
 #else
 typedef struct semaphore	_mutex;
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+typedef struct legacy_timer_emu {
+	struct timer_list t;
+	void (*function)(unsigned long);
+	unsigned long data;
+} _timer;
+#else
 typedef struct timer_list _timer;
+#endif
 
 struct	__queue	{
 	struct	list_head	queue;
@@ -251,19 +259,39 @@ __inline static void rtw_list_delete(_list *plist) {
 
 #define RTW_TIMER_HDL_ARGS void *FunctionContext
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+static void legacy_timer_emu_func(struct timer_list *t)
+{
+	struct legacy_timer_emu *lt = from_timer(lt, t, t);
+	lt->function(lt->data);
+}
+#endif
+
 __inline static void _init_timer(_timer *ptimer, _nic_hdl nic_hdl, void *pfunc, void *cntx) {
 	/* setup_timer(ptimer, pfunc,(u32)cntx);	 */
 	ptimer->function = pfunc;
 	ptimer->data = (unsigned long)cntx;
-	init_timer(ptimer);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	timer_setup(&ptimer->t, legacy_timer_emu_func, 0);
+#else
+ 	init_timer(ptimer);
+#endif
 }
 
 __inline static void _set_timer(_timer *ptimer, u32 delay_time) {
-	mod_timer(ptimer , (jiffies + (delay_time * HZ / 1000)));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	mod_timer(&ptimer->t, (jiffies+(delay_time*HZ/1000)));
+#else
+ 	mod_timer(ptimer , (jiffies + (delay_time * HZ / 1000)));
+#endif
 }
 
 __inline static void _cancel_timer(_timer *ptimer, u8 *bcancelled) {
-	del_timer_sync(ptimer);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	del_timer_sync(&ptimer->t);
+#else
+ 	del_timer_sync(ptimer);
+#endif
 	*bcancelled = 1;
 }
 


### PR DESCRIPTION
I was able to solve #10 and get this driver working by applying the changes from https://github.com/aircrack-ng/rtl8812au/commit/f221a169f281dab9756a176ec2abd91e0eba7d19 to this repo.

I'm not familiar with Linux driver development, so I don't know if this is a good solution or not, but I wanted to leave this here for anyone else since it is working for me.